### PR TITLE
Bugfix/snmp write buffers

### DIFF
--- a/include/lwip/apps/snmp_opts.h
+++ b/include/lwip/apps/snmp_opts.h
@@ -122,7 +122,7 @@
  * The maximum length of strings used.
  */
 #if !defined SNMP_MAX_OCTET_STRING_LEN || defined __DOXYGEN__
-#define SNMP_MAX_OCTET_STRING_LEN       127
+#define SNMP_MAX_OCTET_STRING_LEN       255
 #endif
 
 /**

--- a/src/snmp_msg.h
+++ b/src/snmp_msg.h
@@ -154,7 +154,8 @@ struct snmp_request {
 
 //u8_t value_buffer[SNMP_MAX_VALUE_SIZE];
 /* _HT_ I think that a length of 128 should be supported. */
-#define SNMP_VALUE_BUFFER_SIZE   64
+//#define SNMP_VALUE_BUFFER_SIZE   64
+#define SNMP_VALUE_BUFFER_SIZE   128
 
   u8_t value_buffer[SNMP_VALUE_BUFFER_SIZE];
 };

--- a/src/snmp_msg.h
+++ b/src/snmp_msg.h
@@ -152,7 +152,7 @@ struct snmp_request {
   u16_t outbound_scoped_pdu_string_offset;
 #endif
 
-u8_t value_buffer[SNMP_MAX_VALUE_SIZE];
+  u8_t value_buffer[SNMP_MAX_VALUE_SIZE];
 };
 
 /** A helper struct keeping length information about varbinds */

--- a/src/snmp_msg.h
+++ b/src/snmp_msg.h
@@ -152,12 +152,7 @@ struct snmp_request {
   u16_t outbound_scoped_pdu_string_offset;
 #endif
 
-//u8_t value_buffer[SNMP_MAX_VALUE_SIZE];
-/* _HT_ I think that a length of 128 should be supported. */
-//#define SNMP_VALUE_BUFFER_SIZE   64
-#define SNMP_VALUE_BUFFER_SIZE   128
-
-  u8_t value_buffer[SNMP_VALUE_BUFFER_SIZE];
+u8_t value_buffer[SNMP_MAX_VALUE_SIZE];
 };
 
 /** A helper struct keeping length information about varbinds */


### PR DESCRIPTION
Increase buffer to be able to write sysdesc, sysname and syslocation to MIB